### PR TITLE
Adds introspection rules for South

### DIFF
--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -108,3 +108,14 @@ class CanonicalNameEnumField(models.CharField):
             return self.enum.from_canonical(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an RichEnumValue.' % (value, type(value)))
+
+
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], [
+        "^django_richenum\.models\.fields\.IndexEnumField",
+        "^django_richenum\.models\.fields\.LaxIndexEnumField",
+        "^django_richenum\.models\.fields\.CanonicalNameEnumField",
+    ])
+except ImportError:
+    pass


### PR DESCRIPTION
[South](https://pypi.python.org/pypi/South) reports an error when creating schema migrations using the richenum fields.

```
! Cannot freeze field 'myapp.mymodel.index_enum_field'
! (this field has class django_richenum.models.fields.IndexEnumField)
! Cannot freeze field 'myapp.mymodel.lax_index_enum_field'
! (this field has class django_richenum.models.fields.LaxIndexEnumField)
! Cannot freeze field 'myapp.mymodel.canonical_enum_field'
! (this field has class django_richenum.models.fields.CanonicalNameEnumField)

! South cannot introspect some fields; this is probably because they are custom
! fields. If they worked in 0.6 or below, this is because we have removed the
! models parser (it often broke things).
! To fix this, read http://south.aeracode.org/wiki/MyFieldsDontWork
```

Adding the [introspection rules](http://south.readthedocs.org/en/latest/customfields.html#extending-introspection) allows South to generate the schema.

The ruleset is conditionally blocked off for those not using South.
