### PR TITLE
Elements with single blank elements as strings causes a form.is_valid().

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 | `Dale Hui <http://github.com/dhui>`_
 | `Robert MacCloy <http://github.com/rbm>`_
 | `Ben Lopatin <http://github.com/bennylope>`_
+| `Roger Hu <http://github.com/rogerhu>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.2.1 (2013-12-09)
+------------------
+    - Single element lists with an empty string in TypedMultipleChoiceField are considered empty values.
+
 1.2.0 (2013-12-03)
 ------------------
     - Add enum-aware versions of TypedMultipleChoiceField.

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='1.2.0',
+    version='1.2.1',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/django_richenum/forms/fields.py
+++ b/src/django_richenum/forms/fields.py
@@ -105,6 +105,14 @@ class IndexEnumField(_BaseIndexField, forms.TypedChoiceField):
 class MultipleCanonicalEnumField(_BaseCanonicalField, forms.TypedMultipleChoiceField):
     _empty_value_factory = lambda x: []
 
+    def __init__(self, *args, **kwargs):
+        super(MultipleCanonicalEnumField, self).__init__(*args, **kwargs)
+
+        # Breaking change in Django v1.6 - https://code.djangoproject.com/ticket/21397
+        # Django's coerce() method must always return a value present in the choices fields.
+        if hasattr(self, 'empty_values'):
+            self.empty_values.append([u''])
+
 
 class MultipleIndexEnumField(_BaseIndexField, forms.TypedMultipleChoiceField):
     _empty_value_factory = lambda x: []

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -167,6 +167,10 @@ class MultiCanonicalFormTests(TestCase):
         with self.assertRaises(ValueError):
             MultipleCanonicalEnumField(Fruit, choices=choices)
 
+    def test_empty_value(self):
+        form = MultipleCanonicalForm({'num': ['one'], 'fruit': ['apple', 'peach'], 'fruit_optional': ['']})
+        self.assertTrue(form.is_valid())
+
 
 class MultipleIndexForm(forms.Form):
     num = MultipleIndexEnumField(Number)


### PR DESCRIPTION
If a user submits fruit_optional= in the query parameter, Django interprets this value
as [u''].  Include this element as an empty value.

@akshayjshah @adepue @rbm
