### PR TITLE
Support syncdb/migrate in django 1.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='2.0.0',
+    version='2.1.0',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -18,6 +18,12 @@ class IndexEnumField(models.IntegerField):
         self.enum = enum
         super(IndexEnumField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(IndexEnumField, self).deconstruct()
+        args.insert(0, self.enum)
+
+        return name, path, args, kwargs
+
     def get_default(self):
         # Override Django's implementation, which casts all default values to
         # unicode.
@@ -78,6 +84,12 @@ class CanonicalNameEnumField(models.CharField):
             raise TypeError("%s doesn't support canonical_name lookup." % enum)
         self.enum = enum
         super(CanonicalNameEnumField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(CanonicalNameEnumField, self).deconstruct()
+        args.insert(0, self.enum)
+
+        return name, path, args, kwargs
 
     def get_default(self):
         # Override Django's implementation, which casts all default values to


### PR DESCRIPTION
Need to override the deconstruct method for migrate support in Django 1.7

https://docs.djangoproject.com/en/dev/releases/1.7/#new-method-on-field-subclasses

@rbm @dhui @akshayjshah @rogerhu 
