### PR TITLE
Support Django model field usage in ModelForms with backends other than SQLite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,28 @@ language: python
 python:
   - "2.7"
 env:
-  - DJANGO_VERSION_CEILING=1.4
-  - DJANGO_VERSION_CEILING=1.5
-  - DJANGO_VERSION_CEILING=1.6
-  - DJANGO_VERSION_CEILING=1.7
-  - DJANGO_VERSION_CEILING=1.8
+  - DJANGO_VERSION_CEILING=1.4 DJANGO_DB_ENGINE=sqlite
+  - DJANGO_VERSION_CEILING=1.4 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+  - DJANGO_VERSION_CEILING=1.4 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+  - DJANGO_VERSION_CEILING=1.5 DJANGO_DB_ENGINE=sqlite
+  - DJANGO_VERSION_CEILING=1.5 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+  - DJANGO_VERSION_CEILING=1.5 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+  - DJANGO_VERSION_CEILING=1.6 DJANGO_DB_ENGINE=sqlite
+  - DJANGO_VERSION_CEILING=1.6 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+  - DJANGO_VERSION_CEILING=1.6 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+  - DJANGO_VERSION_CEILING=1.7 DJANGO_DB_ENGINE=sqlite
+  - DJANGO_VERSION_CEILING=1.7 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+  - DJANGO_VERSION_CEILING=1.7 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
+  - DJANGO_VERSION_CEILING=1.8 DJANGO_DB_ENGINE=sqlite
+  - DJANGO_VERSION_CEILING=1.8 DJANGO_DB_ENGINE=postgres DJANGO_DB_NAME=testdb DJANGO_DB_USER=postgres
+  - DJANGO_VERSION_CEILING=1.8 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 install:
-  - pip install -q "Django<$DJANGO_VERSION_CEILING"
+  - pip install -q "Django<$DJANGO_VERSION_CEILING" MySQL-python psycopg2
   - pip install -q flake8 pylint pylint-django django-nose
   - pip install -e .
+before_script:
+  - "mysql -e 'create database testdb;'"
+  - "psql -c 'create database testdb;' -U postgres"
 script:
   - python setup.py test
   - flake8 tests src setup.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.2.0 (2015-03-11)
+------------------
+    - Support ModelForms for non-SQLite DB backends
+
+2.1.0 (2014-11-01)
+------------------
+    - Support migration in Django 1.7
+
 2.0.0 (2014-09-04)
 ------------------
     - Support Django 1.7, drop support for Python 2.6.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='2.1.0',
+    version='2.2.0',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,36 @@ class DjangoTest(TestCommand):
 
     def run_tests(self):
         from django.conf import settings
+
+        db_engine = os.environ.get('DJANGO_DB_ENGINE', 'sqlite')
+        if db_engine == 'mysql':
+            db_settings = {
+                'ENGINE': 'django.db.backends.mysql',
+                'NAME': os.environ['DJANGO_DB_NAME'],
+                'USER': os.environ['DJANGO_DB_USER'],
+            }
+        elif db_engine == 'postgres':
+            db_settings = {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'NAME': os.environ['DJANGO_DB_NAME'],
+                'USER': os.environ['DJANGO_DB_USER'],
+            }
+        elif db_engine == 'sqlite':
+            db_settings = {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': os.path.join(self.DIRNAME, 'database.db'),
+            }
+        else:
+            raise ValueError("Unknown DB engine: %s" % db_engine)
+
         settings.configure(
             DEBUG=True,
-            DATABASES={
-                'default': {
-                    'ENGINE': 'django.db.backends.sqlite3',
-                    'NAME': os.path.join(self.DIRNAME, 'database.db')}},
+            DATABASES={'default': db_settings},
             CACHES={
                 'default': {
-                    'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
+                    'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
+                }
+            },
             MIDDLEWARE_CLASSES=['django.middleware.common.CommonMiddleware'],
             INSTALLED_APPS=('django_nose',) + self.APPS)
 

--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -54,6 +54,19 @@ class IndexEnumField(models.IntegerField):
         else:
             raise TypeError('Cannot interpret %s (%s) as an OrderedRichEnumValue.' % (value, type(value)))
 
+    def run_validators(self, value):
+        """
+        Validate that the value is of the correct type for Model field validation
+        Model fields are only validated during ModelForm.clean().
+        https://docs.djangoproject.com/en/1.7/ref/validators/#how-validators-are-run
+        The value used for validation hasn't been converted for DB storage yet
+        but is validated using validators that are DB specific.
+        So we need to cast the value to one used for DB storage.
+        """
+        if isinstance(value, OrderedRichEnumValue):
+            value = value.index
+        return super(IndexEnumField, self).run_validators(value)
+
 
 class LaxIndexEnumField(IndexEnumField):
     '''Like IndexEnumField, but also allows casting to and from
@@ -120,6 +133,19 @@ class CanonicalNameEnumField(models.CharField):
             return self.enum.from_canonical(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an RichEnumValue.' % (value, type(value)))
+
+    def run_validators(self, value):
+        """
+        Validate that the value is of the correct type for Model field validation
+        Model fields are only validated during ModelForm.clean().
+        https://docs.djangoproject.com/en/1.7/ref/validators/#how-validators-are-run
+        The value used for validation hasn't been converted for DB storage yet
+        but is validated using validators that are DB specific.
+        So we need to cast the value to one used for DB storage.
+        """
+        if isinstance(value, RichEnumValue):
+            value = value.canonical_name
+        return super(CanonicalNameEnumField, self).run_validators(value)
 
 
 try:

--- a/tests/test_model_form.py
+++ b/tests/test_model_form.py
@@ -1,0 +1,26 @@
+from django import forms
+from django.utils.unittest import TestCase
+
+from .models import NumNode
+
+
+class NumNodeModelForm(forms.ModelForm):
+
+    class Meta:
+        model = NumNode
+        # explicitly list the all fields for compatibility across Django version
+        fields = ("num", "num_nullable", "num_lax", "num_str", "num_str_nullable", )
+
+
+class ModelFormTests(TestCase):
+
+    def test_model_form(self):
+        form_data = {
+            "num": "1",
+            "num_nullable": "1",
+            "num_lax": "1",
+            "num_str": "one",
+            "num_str_nullable": "one",
+        }
+        form = NumNodeModelForm(form_data)
+        self.assertTrue(form.is_valid(), form.errors)


### PR DESCRIPTION
Model fields are only validated in ModelForms:
https://docs.djangoproject.com/en/1.7/ref/validators/#how-validators-are-run

However, the specifics as to which validations are run are DB backend specific.

The SQLite DB backend (which is currently used for unittests) does not validate Django model  IntegerFields.
https://github.com/django/django/blob/1.7.6/django/db/backends/sqlite3/base.py#L300
The other DB backends do validate the min/max range for the IntegerField.
https://github.com/django/django/blob/1.7.6/django/db/backends/__init__.py#L1328
The `integer_field_range()` method is not overwritten for the MySQL, Postgres, or Oracle backends.

So, currently django_richenum model fields don't work with Django ModelForms for non-SQLite DB backends.
This is a problem since very few people run SQLite as the DB backend for production.


The `IntegerField` and `CharField` for Django models perform validation.
https://github.com/django/django/blob/1.7.6/django/db/models/fields/__init__.py#L1590
https://github.com/django/django/blob/1.7.6/django/db/models/fields/__init__.py#L1013

All that being said, I'm not sure how to write unittests for this since you'd need to use some other DB backend besides SQLite. One option would be to inherit from the SQLite backend but make the `integer_field_range()` method use `super()` instead of disabling the default validation. However, this is a very hacky approach, but it works.