### PR TITLE
Fix form field rendering

### DIFF
--- a/src/django_richenum/forms/fields.py
+++ b/src/django_richenum/forms/fields.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from django import forms
 from django.core.exceptions import ValidationError
 
-from richenum import EnumLookupError
+from richenum import EnumLookupError, OrderedRichEnumValue
 
 
 try:
@@ -104,6 +104,11 @@ class _BaseIndexField(_BaseEnumField):
             value = self.coerce_value(value)
 
         return super(_BaseIndexField, self).valid_value(value)
+
+    def prepare_value(self, value):
+        if isinstance(value, OrderedRichEnumValue):
+            return value.index
+        return super(_BaseIndexField, self).prepare_value(value)
 
 
 class CanonicalEnumField(_BaseCanonicalField, forms.TypedChoiceField):


### PR DESCRIPTION
Bug
----
   - IndexEnumField in bound forms were not selecting the correct value when used with ModelForms
      - The display_name of the selected value was being compared with (and not matching) the index

Fix
---
   - Use the hidden API `prepare_value()` to make the selected value match choices
      - Some of Django 1.8.3's built-in form fields (`DateTimeField`, `DurationField`, `UUIDField`, and `ModelChoiceField`) also use `prepare_value()`

Truncated call stack:
* Form rendering a bound field:
  * https://github.com/django/django/blob/1.8.3/django/forms/forms.py#L241
* BoundField being rendered
  1. https://github.com/django/django/blob/1.8.3/django/forms/forms.py#L533
  1. https://github.com/django/django/blob/1.8.3/django/forms/forms.py#L593
* BoundField rendering calling `prepare_value()`
  * https://github.com/django/django/blob/1.8.3/django/forms/forms.py#L640

Other fields using prepare value:
* https://github.com/django/django/blob/1.8.3/django/forms/fields.py
* https://github.com/django/django/blob/1.8.3/django/forms/models.py#L1205