### PR TITLE
Support filtering by RichEnum model fields in the Django admin UI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,12 @@ CanonicalEnumField
 IndexEnumField
   Uses the OrderedRichEnum index as form field values.
 
+-----------
+Django Admin
+-----------
+RichEnumFieldListFilter
+  Enables filtering by RichEnum model fields in the Django admin UI
+
 -----
 Links
 -----
@@ -96,6 +102,14 @@ CanonicalNameEnumField
     >>> m.my_enum
     RichEnumValue - canonical_name: 'bar'  display_name: 'Bar'
     >>> MyModel.objects.filter(my_enum=MyRichEnum.BAR)
+
+----------------------
+RichEnumFieldListFilter
+----------------------
+.. code:: python
+
+    >>> from django_richenum.admin import register_admin_filters
+    >>> register_admin_filters()
 
 
 ================

--- a/src/django_richenum/admin/__init__.py
+++ b/src/django_richenum/admin/__init__.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+
+from .filters import RichEnumFieldListFilter
+from ..models.fields import IndexEnumField, LaxIndexEnumField, CanonicalNameEnumField
+
+
+__registered = False
+
+
+def register_admin_filters():
+    """
+    Registers RichEnum model field filters for usage with the Django admin UI
+    The filters are registered only on the first call to this function
+    """
+    global __registered  # Use the module level __registered variable
+
+    if not __registered:
+        admin.FieldListFilter.register(
+            lambda f: isinstance(f, (IndexEnumField, LaxIndexEnumField, CanonicalNameEnumField)),
+            RichEnumFieldListFilter,
+            take_priority=True)
+
+        __registered = True

--- a/src/django_richenum/admin/filters.py
+++ b/src/django_richenum/admin/filters.py
@@ -1,0 +1,64 @@
+from django import forms
+from django.contrib import admin
+from django.utils.encoding import smart_text
+from django.utils.translation import ugettext_lazy as _
+
+from ..forms.fields import IndexEnumField as IndexEnumFormField
+from ..forms.fields import CanonicalEnumField as CanonicalNameEnumFormField
+
+from richenum import RichEnum, OrderedRichEnum
+
+
+class RichEnumFieldListFilter(admin.FieldListFilter):
+    def __init__(self, field, request, params, model, model_admin, field_path):
+        self.enum = field.enum
+        self.lookup_kwarg = field_path
+        self.lookup_val = request.GET.get(self.lookup_kwarg)
+
+        # Create a Django form to validate request params
+        form_cls_name = "%sRichEnumFieldListFilterForm" % self.enum.__name__
+        form_attrs = {}
+        if issubclass(self.enum, OrderedRichEnum):
+            form_attrs[self.lookup_kwarg] = IndexEnumFormField(self.enum)
+        elif issubclass(self.enum, RichEnum):
+            form_attrs[self.lookup_kwarg] = CanonicalNameEnumFormField(self.enum)
+
+        self.form_cls = type(form_cls_name, (forms.Form, ), form_attrs)
+
+        super(RichEnumFieldListFilter, self).__init__(field, request, params, model, model_admin, field_path)
+
+    def expected_parameters(self):
+        return [self.lookup_kwarg]
+
+    def choices(self, cl):
+        yield {
+            "selected": self.lookup_val is None,
+            "query_string": cl.get_query_string({}, [self.lookup_kwarg]),
+            "display": _("All"),
+        }
+
+        # Generate choices based off of RichEnum
+        # Note: if the RichEnumValues are modified, the data stored in the DB may be out of sync from the RichEnum
+        choices = ()
+        if issubclass(self.enum, OrderedRichEnum):
+            choices = self.enum.choices("index")
+        elif issubclass(self.enum, RichEnum):
+            choices = self.enum.choices()
+
+        for lookup, title in choices:
+            yield {
+                "selected": smart_text(lookup) == self.lookup_val,
+                "query_string": cl.get_query_string({
+                    self.lookup_kwarg: lookup}),
+                "display": title,
+            }
+
+    def queryset(self, request, queryset):
+        kwargs = {}
+
+        # Validate filter params
+        form = self.form_cls(request.GET)
+        if form.is_valid():
+            kwargs[self.lookup_kwarg] = form.cleaned_data[self.lookup_kwarg]
+
+        return queryset.filter(**kwargs)


### PR DESCRIPTION
I tried auto-generating and setting `Field.choices` in the model fields but that doesn't work since the Django admin view handling the filter parameters will filter with values of type string (reading straight for `request.GET`), which doesn't work with IndexEnumFields.

This approach, of registering admin filters for RichEnum model fields, is cleaner and safer as there's no risk of it breaking or changing existing `django_richenum` functionality if the admin filters are not registered.