### PR TITLE
Prep for Python 3.x support and related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - DJANGO_VERSION_CEILING=1.10 DJANGO_DB_ENGINE=mysql DJANGO_DB_NAME=testdb DJANGO_DB_USER=travis
 
 install:
-  - pip install "Django<$DJANGO_VERSION_CEILING" MySQL-python psycopg2
+  - pip install "Django<$DJANGO_VERSION_CEILING" mysqlclient psycopg2
   - pip install -q flake8 pylint pylint-django django-nose
   - pip install -e .
 before_script:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ tests_require = (
 install_requires = (
     'Django>=1.8,<1.10',
     'richenum',
+    'six',
 )
 
 

--- a/src/django_richenum/__init__.py
+++ b/src/django_richenum/__init__.py
@@ -1,13 +1,3 @@
-import forms  # noqa
-import models  # noqa
-
-
-__all__ = (
-    'forms',
-    'models',
-)
-
-
 __version__ = 'unknown'
 try:
     __version__ = __import__('pkg_resources').get_distribution('django_richenum').version

--- a/src/django_richenum/forms/fields.py
+++ b/src/django_richenum/forms/fields.py
@@ -19,7 +19,9 @@ class CooperativeMeta(ABCMeta, RenameFieldMethods):
 
 class _BaseEnumField(object):
     __metaclass__ = CooperativeMeta
-    _empty_value_factory = lambda x: None
+
+    def _empty_value_factory(self):
+        return None
 
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
@@ -120,8 +122,10 @@ class IndexEnumField(_BaseIndexField, forms.TypedChoiceField):
 
 
 class MultipleCanonicalEnumField(_BaseCanonicalField, forms.TypedMultipleChoiceField):
-    _empty_value_factory = lambda x: []
+    def _empty_value_factory(self):
+        return []
 
 
 class MultipleIndexEnumField(_BaseIndexField, forms.TypedMultipleChoiceField):
-    _empty_value_factory = lambda x: []
+    def _empty_value_factory(self):
+        return []

--- a/src/django_richenum/forms/fields.py
+++ b/src/django_richenum/forms/fields.py
@@ -1,5 +1,7 @@
 from abc import ABCMeta
 from abc import abstractmethod
+import six
+
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -74,7 +76,7 @@ class _BaseCanonicalField(_BaseEnumField):
 
     # In Django 1.6, value is coerced already. Below 1.6, we need to manually coerce
     def valid_value(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             value = self.coerce_value(value)
         return super(_BaseCanonicalField, self).valid_value(value)
 
@@ -96,7 +98,7 @@ class _BaseIndexField(_BaseEnumField):
     # In Django 1.6, value is coerced already. Below 1.6, we need to manually coerce
     def valid_value(self, value):
         # In < Dango 1.6, this comes in as a string, so we should flip it to be an int
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             try:
                 value = int(value)
             except ValueError as e:

--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -44,6 +44,11 @@ class IndexEnumField(models.IntegerField):
         else:
             raise TypeError('Cannot convert value: %s (%s) to an int.' % (value, type(value)))
 
+    def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return value
+        return self.enum.from_index(value)
+
     def to_python(self, value):
         # Convert value to OrderedRichEnumValue. (Called on *all* assignments
         # to the field, including object creation from a DB record.)
@@ -80,6 +85,11 @@ class LaxIndexEnumField(IndexEnumField):
         if isinstance(value, basestring):
             return self.enum.from_canonical(value).index
         return super(LaxIndexEnumField, self).get_prep_value(value)
+
+    def from_db_value(self, value, expression, connection, context):
+        if isinstance(value, six.string_types):
+            return self.enum.from_canonical(value)
+        return super(LaxIndexEnumField, self).from_db_value(value, expression, connection, context)
 
     def to_python(self, value):
         if isinstance(value, basestring):
@@ -125,6 +135,11 @@ class CanonicalNameEnumField(models.CharField):
             return value
         else:
             raise TypeError('Cannot convert value: %s (%s) to a string.' % (value, type(value)))
+
+    def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return value
+        return self.enum.from_canonical(value)
 
     def to_python(self, value):
         # Convert value to RichEnumValue. (Called on *all* assignments

--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -1,4 +1,4 @@
-import numbers
+import six
 
 from django.db import models
 
@@ -39,7 +39,7 @@ class IndexEnumField(models.IntegerField):
             return None
         elif isinstance(value, OrderedRichEnumValue):
             return value.index
-        elif isinstance(value, numbers.Integral):
+        elif isinstance(value, six.integer_types):
             return value
         else:
             raise TypeError('Cannot convert value: %s (%s) to an int.' % (value, type(value)))
@@ -56,7 +56,7 @@ class IndexEnumField(models.IntegerField):
             return None
         elif isinstance(value, OrderedRichEnumValue):
             return value
-        elif isinstance(value, numbers.Integral):
+        elif isinstance(value, six.integer_types):
             return self.enum.from_index(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an OrderedRichEnumValue.' % (value, type(value)))
@@ -82,7 +82,7 @@ class LaxIndexEnumField(IndexEnumField):
     Mainly used to help migrate existing code that uses strings as database values.
     '''
     def get_prep_value(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             return self.enum.from_canonical(value).index
         return super(LaxIndexEnumField, self).get_prep_value(value)
 
@@ -92,7 +92,7 @@ class LaxIndexEnumField(IndexEnumField):
         return super(LaxIndexEnumField, self).from_db_value(value, expression, connection, context)
 
     def to_python(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             return self.enum.from_canonical(value)
         return super(LaxIndexEnumField, self).to_python(value)
 
@@ -131,7 +131,7 @@ class CanonicalNameEnumField(models.CharField):
             return None
         elif isinstance(value, RichEnumValue):
             return value.canonical_name
-        elif isinstance(value, basestring):
+        elif isinstance(value, six.string_types):
             return value
         else:
             raise TypeError('Cannot convert value: %s (%s) to a string.' % (value, type(value)))
@@ -148,7 +148,7 @@ class CanonicalNameEnumField(models.CharField):
             return None
         elif isinstance(value, RichEnumValue):
             return value
-        elif isinstance(value, basestring):
+        elif isinstance(value, six.string_types):
             return self.enum.from_canonical(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an RichEnumValue.' % (value, type(value)))


### PR DESCRIPTION
I'm unable to get the following tests passing in Python 3:
* `test_assignment_casts_ints_to_enum_values()`
* `test_assignment_casts_strs_to_enum_values()`

But a good chunk of the groundwork for Python 3 support is done in this PR.
This will also allow for future work to be Python 3 compatible.