### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django-richenum
     :alt: Build Status
     :target: https://travis-ci.org/hearsaycorp/django-richenum
 
-.. image:: https://pypip.in/v/django-richenum/badge.png
+.. image:: https://img.shields.io/pypi/v/django-richenum.svg
     :alt: Latest PyPI Version
     :target: https://pypi.python.org/pypi/django-richenum/
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-richenum))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-richenum`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.