### PR TITLE
Add Django 3.1, Python 3.8, and 3.9 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require = (
 
 
 install_requires = (
-    'Django>=1.11,<3.1',
+    'Django>=1.11,<3.2',
     'richenum',
     'six',
 )
@@ -87,7 +87,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='3.8.0',
+    version='3.9.0',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +
@@ -106,6 +106,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     keywords='python django enum richenum',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = {py27,py35}-django{111}-{sqlite,mysql,postgres},
           {py35,py36,py37}-django{210,220}-{sqlite,mysql,postgres},lint
-          {py36,py37}-django{300}-{sqlite,mysql,postgres},lint
+          {py36,py37,py39}-django{300,310}-{sqlite,mysql,postgres},lint
 
 [gh-actions]
 python =
@@ -9,6 +9,8 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
+    3.9: py39
 
 [testenv]
 deps =
@@ -16,6 +18,7 @@ deps =
     django210: Django>=2.1,<2.2
     django220: Django>=2.2,<2.3
     django300: Django>=2.3,<3.1
+    django310: Django>=2.3,<3.2
     pytest
     pytest-django
     mysqlclient


### PR DESCRIPTION
Just bumping the supported versions. Tests still passing with flying colors.