### PR TITLE
Uprate python constraints to 3.7-3.10; remove six; uprate django version constraints.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@hearsaycorp/platform

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     services:
       postgres:
         image: postgres:11

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 tests_require = (
-    'pytest<5.0',
+    'pytest>=6.2.5,<7.2',
     'pytest-django',
 )
 
@@ -64,6 +64,7 @@ class DjangoTest(TestCommand):
         settings.configure(
             DEBUG=True,
             DATABASES={'default': db_settings},
+            SECRET_KEY=os.environ.get('SECRET_KEY'),
             CACHES={
                 'default': {
                     'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
@@ -86,7 +87,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='3.9.0',
+    version='4.0.0',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +
@@ -95,15 +96,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
-
 
 tests_require = (
     'pytest<5.0',
@@ -13,9 +13,8 @@ tests_require = (
 
 
 install_requires = (
-    'Django>=1.11,<3.1',
+    'Django>=2.2,<3.3',
     'richenum',
-    'six',
 )
 
 
@@ -29,9 +28,9 @@ class DjangoTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
+        import django
         import pytest
         from django.conf import settings
-        import django
 
         db_host = os.environ.get('DJANGO_DB_HOST')
         db_engine = os.environ.get('DJANGO_DB_ENGINE', 'sqlite')
@@ -87,7 +86,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django-richenum',
-    version='3.8.0',
+    version='3.9.0',
     description='Django Enum library for python.',
     long_description=(
         open('README.rst').read() + '\n\n' +
@@ -106,6 +105,9 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     keywords='python django enum richenum',

--- a/src/django_richenum/admin/options.py
+++ b/src/django_richenum/admin/options.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 
-import six
-
-from ..models.fields import IndexEnumField, LaxIndexEnumField, CanonicalNameEnumField
+from ..models.fields import CanonicalNameEnumField
+from ..models.fields import IndexEnumField
+from ..models.fields import LaxIndexEnumField
 
 RICH_ENUM_FORMFIELD_FOR_DBFIELD_DEFAULTS = {
     IndexEnumField: {},
@@ -16,5 +16,5 @@ class RichEnumModelAdmin(admin.ModelAdmin):
         super(RichEnumModelAdmin, self).__init__(*args, **kwargs)
 
         # Update unspecified internal formfields
-        for model_field_cls, formfield_override_value in six.iteritems(RICH_ENUM_FORMFIELD_FOR_DBFIELD_DEFAULTS):
+        for model_field_cls, formfield_override_value in RICH_ENUM_FORMFIELD_FOR_DBFIELD_DEFAULTS.items():
             self.formfield_overrides.setdefault(model_field_cls, formfield_override_value)

--- a/src/django_richenum/forms/fields.py
+++ b/src/django_richenum/forms/fields.py
@@ -1,12 +1,10 @@
 from abc import ABCMeta
 from abc import abstractmethod
-import six
 
 from django import forms
 from django.core.exceptions import ValidationError
-
-from richenum import EnumLookupError, OrderedRichEnumValue
-
+from richenum import EnumLookupError
+from richenum import OrderedRichEnumValue
 
 try:
     from django.forms.fields import RenameFieldMethods  # pylint: disable=no-name-in-module
@@ -76,7 +74,7 @@ class _BaseCanonicalField(_BaseEnumField):
 
     # In Django 1.6, value is coerced already. Below 1.6, we need to manually coerce
     def valid_value(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = self.coerce_value(value)
         return super(_BaseCanonicalField, self).valid_value(value)
 
@@ -98,7 +96,7 @@ class _BaseIndexField(_BaseEnumField):
     # In Django 1.6, value is coerced already. Below 1.6, we need to manually coerce
     def valid_value(self, value):
         # In < Dango 1.6, this comes in as a string, so we should flip it to be an int
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             try:
                 value = int(value)
             except ValueError as e:

--- a/src/django_richenum/models/fields.py
+++ b/src/django_richenum/models/fields.py
@@ -1,8 +1,6 @@
-import six
-
 from django.db import models
-
-from richenum import RichEnumValue, OrderedRichEnumValue
+from richenum import OrderedRichEnumValue
+from richenum import RichEnumValue
 
 
 # https://github.com/django/django/blob/64200c14e0072ba0ffef86da46b2ea82fd1e019a/django/db/models/fields/subclassing.py#L31-L44
@@ -61,7 +59,7 @@ class IndexEnumField(models.IntegerField):
             return None
         elif isinstance(value, OrderedRichEnumValue):
             return value.index
-        elif isinstance(value, six.integer_types):
+        elif isinstance(value, int):
             return value
         else:
             raise TypeError('Cannot convert value: %s (%s) to an int.' % (value, type(value)))
@@ -80,7 +78,7 @@ class IndexEnumField(models.IntegerField):
             return None
         elif isinstance(value, OrderedRichEnumValue):
             return value
-        elif isinstance(value, six.integer_types):
+        elif isinstance(value, int):
             return self.enum.from_index(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an OrderedRichEnumValue.' % (value, type(value)))
@@ -114,19 +112,19 @@ class LaxIndexEnumField(IndexEnumField):
     Mainly used to help migrate existing code that uses strings as database values.
     '''
     def get_prep_value(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return self.enum.from_canonical(value).index
         return super(LaxIndexEnumField, self).get_prep_value(value)
 
     def from_db_value(self, value, expression, connection, *args):
         # context param is deprecated in Django 2.x will be removed in Django 3.x
         # having *args allows this code to run in Django 1.x and Django 2.x
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return self.enum.from_canonical(value)
         return super(LaxIndexEnumField, self).from_db_value(value, expression, connection, *args)
 
     def to_python(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return self.enum.from_canonical(value)
         return super(LaxIndexEnumField, self).to_python(value)
 
@@ -170,7 +168,7 @@ class CanonicalNameEnumField(models.CharField):
             return None
         elif isinstance(value, RichEnumValue):
             return value.canonical_name
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             return value
         else:
             raise TypeError('Cannot convert value: %s (%s) to a string.' % (value, type(value)))
@@ -189,7 +187,7 @@ class CanonicalNameEnumField(models.CharField):
             return None
         elif isinstance(value, RichEnumValue):
             return value
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             return self.enum.from_canonical(value)
         else:
             raise TypeError('Cannot interpret %s (%s) as an RichEnumValue.' % (value, type(value)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,9 @@
 [tox]
-envlist = {py27,py35}-django{111}-{sqlite,mysql,postgres},
-          {py35,py36,py37,py38,py39,py310}-django{210,220}-{sqlite,mysql,postgres},lint
-          {py36,py37,py38,py39,py310}-django{300,310,320}-{sqlite,mysql,postgres},lint
+envlist = {py37,py38,py39,py310}-django{220}-{sqlite,mysql,postgres},lint
+          {py37,py38,py39,py310}-django{300,310,320}-{sqlite,mysql,postgres},lint
 
 [gh-actions]
 python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -15,13 +11,11 @@ python =
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django210: Django>=2.1,<2.2
     django220: Django>=2.2,<2.3
     django300: Django>=2.3,<3.1
     django310: Django>=3.1,<3.2
     django320: Django>=3.2,<3.3
-    pytest
+    pytest>=6.2.5,<7.2
     pytest-django
     mysqlclient
     psycopg2
@@ -36,6 +30,7 @@ setenv =
     postgres: DJANGO_DB_ENGINE = postgres
     postgres: DJANGO_DB_USER = travis
     postgres: DJANGO_DB_PASSWORD = travis
+    SECRET_KEY = placeholder # required env variable for django>=3.2
 
 commands =
     python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = {py27,py35}-django{111}-{sqlite,mysql,postgres},
-          {py35,py36,py37}-django{210,220}-{sqlite,mysql,postgres},lint
-          {py36,py37}-django{300}-{sqlite,mysql,postgres},lint
+          {py35,py36,py37,py38,py39,py310}-django{210,220}-{sqlite,mysql,postgres},lint
+          {py36,py37,py38,py39,py310}-django{300,310,320}-{sqlite,mysql,postgres},lint
 
 [gh-actions]
 python =
@@ -9,6 +9,9 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 deps =
@@ -16,6 +19,8 @@ deps =
     django210: Django>=2.1,<2.2
     django220: Django>=2.2,<2.3
     django300: Django>=2.3,<3.1
+    django310: Django>=3.1,<3.2
+    django320: Django>=3.2,<3.3
     pytest
     pytest-django
     mysqlclient


### PR DESCRIPTION
This PR establishes new version constraints for ```python```, ```django```, ```pytest```, adds python support up to 3.10, and removes the dependency on ```six```. Additionally, a ```SECRET_KEY``` is added to the tox.ini file to satisfy django 3.2's environment variable requirement for the same.

Major/minor constraints:
* python 3.7, 3.8, 3.9, 3.10
* django 2.2, 3.0, 3.1, 3.2
* pytest 6.2, 7.0, 7.1

@hearsaycorp/retain-and-grow @hearsaycorp/platform 